### PR TITLE
Specify encoding for `open`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
When installing the package, python's builtin open function may not default to 'utf-8'. This can lead to an error when installing if 'utf-8' is not the default while attempting to read the 'README.md' file. To prevent this, the open function has been specified to use 'utf-8' encoding format.